### PR TITLE
dot-pattern type error for ESLint resolved

### DIFF
--- a/nextjs/src/components/ui/dot-pattern.tsx
+++ b/nextjs/src/components/ui/dot-pattern.tsx
@@ -3,15 +3,15 @@ import { useId } from "react";
 import { cn } from "@/lib/utils";
 
 interface DotPatternProps {
-  width?: any;
-  height?: any;
-  x?: any;
-  y?: any;
-  cx?: any;
-  cy?: any;
-  cr?: any;
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  cx?: number;
+  cy?: number;
+  cr?: number;
   className?: string;
-  [key: string]: any;
+  [key: string]: number | string | undefined;
 }
 export function DotPattern({
   width = 16,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix type error in `DotPattern` component by specifying numeric types for properties in `dot-pattern.tsx`.
> 
>   - **Type Definitions**:
>     - Update `DotPatternProps` in `dot-pattern.tsx` to specify `width`, `height`, `x`, `y`, `cx`, `cy`, `cr` as `number`.
>     - Allow additional properties to be `number`, `string`, or `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fmalin.social-art&utm_source=github&utm_medium=referral)<sup> for cb5e0456b0ffb87ba4f8eae643cb738b959d0f8a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->